### PR TITLE
added more info (transparency & linux)

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ To generate an animated spray select multiple images in the file browser.<br />
 The frames are displayed in the same order as they appear in the file browser,<br />
 and each one lasts for 0.2s. Animated gifs are also supported.<br />
 To download final spray click "Save as VTF".<br /><br />
-<span style="color: #cc3333">Transparency is broken in Linux version of TF2!</span><br />
+<span style="color: #cc3333">Transparency is broken in Linux version of TF2 when using DXT1. Use DXT5 instead!</span><br />
 <div id="resolutionNotice" style="visibility: hidden">Using 1024x1020, no mipmaps</div>
 <select class="textInput" value="1024" id="widthSetting" onchange="setResolution()">
 	<option value=1024>1024</option>


### PR DESCRIPTION
It appears that only DXT1 breaks transparency on linux.
DXT5 works.