### PR TITLE
Apply file naming to both VTF and VMT downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,8 @@ Sampling Method: <select class="textInput" value="0" id="sampling">
 </div>
 <p id="progress"></p>
 <br /><br />
+Filename: <input type="text" name="outputFilename" id="outputFilename" value="spray" pattern="[^\\/:\x22*?<>|]+">
+<br /><br />
 <button id="convertButton" type="button" onclick="convert()" disabled>Convert</button> &nbsp; 
 <button id="saveButton" type="button" onclick="createVTF()" disabled>Save as VTF</button> &nbsp;
 <button id="saveButtonVMT" type="button" onclick="downloadVMT()" disabled>Save VMT</button><br />
@@ -153,14 +155,6 @@ changelog:<br />
 </div>
 
 </div>
-<pre id="vmtData" style="display: none">"UnlitGeneric"
-{
-	"$basetexture"	"vgui/logos/spray"
-	"$translucent" "1"
-	"$ignorez" "1"
-	"$vertexcolor" "1"
-	"$vertexalpha" "1"
-}</pre>
 <script src="tga.js" type="text/javascript"></script>
 <script src="libgif.js" type="text/javascript"></script>
 <script src="dither.js" type="text/javascript"></script>

--- a/vtf.css
+++ b/vtf.css
@@ -83,5 +83,8 @@ body {
 #tempCanvas {
 	visibility: hidden;
 }
+#outputFilename:invalid {
+	background-color: pink;
+}
 #videoImporter{
 }

--- a/vtf.js
+++ b/vtf.js
@@ -152,6 +152,7 @@ function handleFileSelect(evt) {
 	var files = evt.target.files; // FileList object
 	if (files.length == 0)
 		return;
+  document.getElementById('outputFilename').value = 'spray';
 	document.getElementById('convertButton').disabled = true;
 	document.getElementById('saveButton').disabled = true;
 	document.getElementById('files0').disabled = true;
@@ -681,7 +682,7 @@ function createVTF() {
 			}
 		}
 	}
-	download(file, "spray.vtf")
+	download(file, "vtf");
 }
 
 //Utils
@@ -1002,9 +1003,16 @@ function reduceColors(data, rb, gb, bb, ab, dith) {
     // context.putImageData(png, 0, 0);
 }
 // Function to download data to a file
-function download(data, filename) {
+function download(data, extension) {
+    var nameField = document.getElementById("outputFilename");
+    if (!nameField.validity.valid) {
+      alert("Filename contains invalid characters");
+      return;
+    }
     var a = document.createElement("a"),
-        file = new Blob([data], {type: "application/octet-stream"});
+        file = new Blob([data], {type: "application/octet-stream"}),
+        name = nameField.value || "spray",
+        filename = name + "." + extension;
     if (window.navigator.msSaveOrOpenBlob) // IE10+
         window.navigator.msSaveOrOpenBlob(file, filename);
     else { // Others
@@ -1069,7 +1077,14 @@ function updateHighestResolution(width,height, framesc){
 }
 
 function downloadVMT(){
-	var vmtName = prompt("Enter name of the spray");
-	var vmtFileText = document.getElementById('vmtData').innerHTML.replace('"vgui/logos/spray"','"vgui/logos/'+vmtName+'"');
-	download(vmtFileText, vmtName+".vmt");
+	var vmtName = document.getElementById("outputFilename").value;
+	var vmtFileText = `"UnlitGeneric"
+{
+	"$basetexture"	"vgui/logos/${vmtName}"
+	"$translucent" "1"
+	"$ignorez" "1"
+	"$vertexcolor" "1"
+	"$vertexalpha" "1"
+}`;
+	download(vmtFileText, "vmt");
 }


### PR DESCRIPTION
Presently, file naming is only available when saving VMT files, while VTF files can only be downloaded as "spray.vtf". The extra step of needing to rename the VTF file after download makes batch conversion of sprays more time consuming than needed.

This pull request adds the ability to name both file types by adding a new input field above the buttons:
![image](https://user-images.githubusercontent.com/7380439/78517937-6eebeb00-77f1-11ea-9c03-5b21640c69d0.png)